### PR TITLE
T-549 Allow tsx (react) component functions to be 75 lines instead of 50

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,5 +41,19 @@ module.exports = {
                 ],
             },
         },
+        {
+            files: ["**/*.tsx"],
+            excludedFiles: "**/*.test.tsx",
+            rules: {
+                "max-lines": [
+                    "error",
+                    { max: 500, skipBlankLines: true, skipComments: true },
+                ],
+                "max-lines-per-function": [
+                    "error",
+                    { max: 75, skipBlankLines: true, skipComments: true },
+                ],
+            },
+        },
     ],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apogeelabs/eslint-config",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "This package provides Apogee's .eslintrc as an extensible shared config",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
I will merge this myself since we have to publish it to npm